### PR TITLE
Make sure WalletUpdateSpent is called on newly inserted txs that are …

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -772,6 +772,8 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pbl
 
             return AddToWallet(wtx);
         }
+        else
+            WalletUpdateSpent(tx);
     }
     return false;
 }


### PR DESCRIPTION
…ours, like staking.
